### PR TITLE
Fix race condition in wrapPerRPCCredentials.GetRequestMetadata

### DIFF
--- a/per_rpc_transport_credentials.go
+++ b/per_rpc_transport_credentials.go
@@ -35,7 +35,7 @@ type wrapPerRPCCredentials struct {
 }
 
 func (w *wrapPerRPCCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	w.executor.AsyncExec(func() {
+	<-w.executor.AsyncExec(func() {
 		if w.FDTransceiver != nil {
 			return
 		}


### PR DESCRIPTION
Files to be sent must be queued up before GetRequestMetadata returns.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
