### PR TITLE
Feature/rework wrap per rpc credentials

### DIFF
--- a/per_rpc_transport_credentials.go
+++ b/per_rpc_transport_credentials.go
@@ -59,13 +59,15 @@ func (w *wrapPerRPCCredentials) SendFD(fd uintptr) <-chan error {
 	var wg sync.WaitGroup
 	w.executor.AsyncExec(func() {
 		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
+			wg.Add(1)
+
 			go func() {
 				if sender != nil {
-					wg.Add(1)
 					defer wg.Done()
 
 					joinErrChs(sender.SendFD(fd), out)
 				} else {
+					wg.Done()
 					wg.Wait()
 					close(out)
 				}
@@ -80,13 +82,13 @@ func (w *wrapPerRPCCredentials) SendFile(file SyscallConn) <-chan error {
 	var wg sync.WaitGroup
 	w.executor.AsyncExec(func() {
 		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
+			wg.Add(1)
 			go func() {
 				if sender != nil {
-					wg.Add(1)
 					defer wg.Done()
-
 					joinErrChs(sender.SendFile(file), out)
 				} else {
+					wg.Done()
 					wg.Wait()
 					close(out)
 				}

--- a/per_rpc_transport_credentials.go
+++ b/per_rpc_transport_credentials.go
@@ -19,8 +19,7 @@
 package grpcfd
 
 import (
-	context "context"
-	"os"
+	"context"
 
 	"github.com/edwarnicke/serialize"
 	"google.golang.org/grpc"
@@ -29,22 +28,16 @@ import (
 
 type wrapPerRPCCredentials struct {
 	credentials.PerRPCCredentials
-	FDTransceiver
-	transceiverFuncs []func(FDTransceiver)
-	executor         serialize.Executor
+	senderFuncs []func(FDSender)
+	executor    serialize.Executor
 }
 
 func (w *wrapPerRPCCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
 	<-w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			return
-		}
-		if transceiver, ok := FromContext(ctx); ok {
-			w.FDTransceiver = transceiver
-			for _, f := range w.transceiverFuncs {
-				f(transceiver)
+		if sender, ok := FromContext(ctx); ok {
+			for _, f := range w.senderFuncs {
+				f(sender)
 			}
-			w.transceiverFuncs = nil
 		}
 	})
 	if w.PerRPCCredentials != nil {
@@ -63,12 +56,8 @@ func (w *wrapPerRPCCredentials) RequireTransportSecurity() bool {
 func (w *wrapPerRPCCredentials) SendFD(fd uintptr) <-chan error {
 	out := make(chan error, 1)
 	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go joinErrChs(w.FDTransceiver.SendFD(fd), out)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
-			go joinErrChs(transceiver.SendFD(fd), out)
+		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
+			go joinErrChs(sender.SendFD(fd), out)
 		})
 	})
 	return out
@@ -77,98 +66,16 @@ func (w *wrapPerRPCCredentials) SendFD(fd uintptr) <-chan error {
 func (w *wrapPerRPCCredentials) SendFile(file SyscallConn) <-chan error {
 	out := make(chan error, 1)
 	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go joinErrChs(w.FDTransceiver.SendFile(file), out)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
+		w.senderFuncs = append(w.senderFuncs, func(transceiver FDSender) {
 			go joinErrChs(transceiver.SendFile(file), out)
 		})
 	})
 	return out
 }
 
-func (w *wrapPerRPCCredentials) RecvFD(dev, inode uint64) <-chan uintptr {
-	out := make(chan uintptr, 1)
-	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go joinFDChs(w.FDTransceiver.RecvFD(dev, inode), out)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
-			go joinFDChs(transceiver.RecvFD(dev, inode), out)
-		})
-	})
-	return out
-}
-
-func (w *wrapPerRPCCredentials) RecvFile(dev, ino uint64) <-chan *os.File {
-	out := make(chan *os.File, 1)
-	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go joinFileChs(w.FDTransceiver.RecvFile(dev, ino), out)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
-			go joinFileChs(transceiver.RecvFile(dev, ino), out)
-		})
-	})
-	return out
-}
-
-func (w *wrapPerRPCCredentials) RecvFileByURL(urlStr string) (<-chan *os.File, error) {
-	dev, ino, err := URLStringToDevIno(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	out := make(chan *os.File, 1)
-	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go joinFileChs(w.FDTransceiver.RecvFile(dev, ino), out)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
-			go joinFileChs(transceiver.RecvFile(dev, ino), out)
-		})
-	})
-	return out, nil
-}
-
-func (w *wrapPerRPCCredentials) RecvFDByURL(urlStr string) (<-chan uintptr, error) {
-	dev, ino, err := URLStringToDevIno(urlStr)
-	if err != nil {
-		return nil, err
-	}
-	out := make(chan uintptr, 1)
-	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go joinFDChs(w.FDTransceiver.RecvFD(dev, ino), out)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
-			go joinFDChs(transceiver.RecvFD(dev, ino), out)
-		})
-	})
-	return out, nil
-}
-
 func joinErrChs(in <-chan error, out chan<- error) {
 	for err := range in {
 		out <- err
-	}
-	close(out)
-}
-
-func joinFileChs(in <-chan *os.File, out chan<- *os.File) {
-	for file := range in {
-		out <- file
-	}
-	close(out)
-}
-
-func joinFDChs(in <-chan uintptr, out chan<- uintptr) {
-	for fd := range in {
-		out <- fd
 	}
 	close(out)
 }
@@ -196,9 +103,9 @@ func PerRPCCredentialsFromCallOptions(opts ...grpc.CallOption) credentials.PerRP
 
 // FromPerRPCCredentials - return grpcfd.FDTransceiver from credentials.PerRPCCredentials
 //                         ok is true of successful, false otherwise
-func FromPerRPCCredentials(rpcCredentials credentials.PerRPCCredentials) (transceiver FDTransceiver, ok bool) {
-	if transceiver, ok = rpcCredentials.(FDTransceiver); ok {
-		return transceiver, true
+func FromPerRPCCredentials(rpcCredentials credentials.PerRPCCredentials) (sender FDSender, ok bool) {
+	if sender, ok = rpcCredentials.(FDSender); ok {
+		return sender, true
 	}
 	return nil, false
 }

--- a/per_rpc_transport_credentials_linux.go
+++ b/per_rpc_transport_credentials_linux.go
@@ -36,12 +36,14 @@ func (w *wrapPerRPCCredentials) SendFilename(filename string) <-chan error {
 	var wg sync.WaitGroup
 	w.executor.AsyncExec(func() {
 		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
+			wg.Add(1)
+
 			go func() {
 				if sender != nil {
-					wg.Add(1)
 					defer wg.Done()
 					joinErrChs(sender.SendFile(file), out)
 				} else {
+					wg.Done()
 					wg.Wait()
 					_ = file.Close()
 					close(out)

--- a/per_rpc_transport_credentials_linux.go
+++ b/per_rpc_transport_credentials_linux.go
@@ -33,18 +33,11 @@ func (w *wrapPerRPCCredentials) SendFilename(filename string) <-chan error {
 		return out
 	}
 	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
+		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
 			go func(in <-chan error, out chan<- error, file *os.File) {
 				joinErrChs(in, out)
 				_ = file.Close()
-			}(w.FDTransceiver.SendFile(file), out, file)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
-			go func(in <-chan error, out chan<- error, file *os.File) {
-				joinErrChs(in, out)
-				_ = file.Close()
-			}(transceiver.SendFile(file), out, file)
+			}(sender.SendFile(file), out, file)
 		})
 	})
 	return out

--- a/per_rpc_transport_credentials_notlinux.go
+++ b/per_rpc_transport_credentials_notlinux.go
@@ -31,14 +31,7 @@ func (w *wrapPerRPCCredentials) SendFilename(filename string) <-chan error {
 		return out
 	}
 	w.executor.AsyncExec(func() {
-		if w.FDTransceiver != nil {
-			go func(in <-chan error, out chan<- error, file *os.File) {
-				joinErrChs(in, out)
-				_ = file.Close()
-			}(w.FDTransceiver.SendFile(file), out, file)
-			return
-		}
-		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
+		w.senderFuncs = append(w.senderFuncs, func(transceiver FDSender) {
 			go func(in <-chan error, out chan<- error, file *os.File) {
 				joinErrChs(in, out)
 				_ = file.Close()

--- a/per_rpc_transport_credentials_notlinux.go
+++ b/per_rpc_transport_credentials_notlinux.go
@@ -36,12 +36,14 @@ func (w *wrapPerRPCCredentials) SendFilename(filename string) <-chan error {
 	var wg sync.WaitGroup
 	w.executor.AsyncExec(func() {
 		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
+			wg.Add(1)
+
 			go func() {
 				if sender != nil {
-					wg.Add(1)
 					defer wg.Done()
 					joinErrChs(sender.SendFile(file), out)
 				} else {
+					wg.Done()
 					wg.Wait()
 					_ = file.Close()
 					close(out)


### PR DESCRIPTION
## Descriptions
Added few changes to grpcfd, made `grpcfd.(*wrapPerRPCCredentials)` to implement `FDSender` interface instead of `FDTransceiver`

## Issue
related to https://github.com/networkservicemesh/sdk/issues/1118