### PR TITLE
Revert "Merge pull request #21 from Mixaster995/feature/rework-wrap-p…

### DIFF
--- a/per_rpc_transport_credentials_linux.go
+++ b/per_rpc_transport_credentials_linux.go
@@ -20,7 +20,6 @@ package grpcfd
 
 import (
 	"os"
-	"sync"
 
 	"golang.org/x/sys/unix"
 )
@@ -33,22 +32,19 @@ func (w *wrapPerRPCCredentials) SendFilename(filename string) <-chan error {
 		close(out)
 		return out
 	}
-	var wg sync.WaitGroup
 	w.executor.AsyncExec(func() {
-		w.senderFuncs = append(w.senderFuncs, func(sender FDSender) {
-			wg.Add(1)
-
-			go func() {
-				if sender != nil {
-					defer wg.Done()
-					joinErrChs(sender.SendFile(file), out)
-				} else {
-					wg.Done()
-					wg.Wait()
-					_ = file.Close()
-					close(out)
-				}
-			}()
+		if w.FDTransceiver != nil {
+			go func(in <-chan error, out chan<- error, file *os.File) {
+				joinErrChs(in, out)
+				_ = file.Close()
+			}(w.FDTransceiver.SendFile(file), out, file)
+			return
+		}
+		w.transceiverFuncs = append(w.transceiverFuncs, func(transceiver FDTransceiver) {
+			go func(in <-chan error, out chan<- error, file *os.File) {
+				joinErrChs(in, out)
+				_ = file.Close()
+			}(transceiver.SendFile(file), out, file)
 		})
 	})
 	return out


### PR DESCRIPTION
## Description
This PR revert changes introduced in https://github.com/edwarnicke/grpcfd/pull/21

After catching problems with tests and deep dive into grpc code, we found that using this changes as described in https://github.com/networkservicemesh/sdk/issues/1118 is not going to work for streaming rpcs.
For streaming rpcs it is not possible to retrieve and use correct `peer` (and therefore extract `FDtransceiver`) until stream is finished. (https://github.com/grpc/grpc-go/blob/master/stream.go#L836)

Since no easy solution is found and we need this to be fixed before release, we decided to revert this changes and rethink this problem from the scratch.
