### PR TITLE
Use sendFDs with sendExecutor

### DIFF
--- a/connwrap.go
+++ b/connwrap.go
@@ -123,6 +123,8 @@ func (w *connWrap) close() error {
 				close(w.errChs[k])
 				_ = syscall.Close(fd)
 			}
+			w.sendFDs = nil
+			w.errChs = nil
 		})
 	})
 	return err


### PR DESCRIPTION
### Description

We got a couple of panics that point to this `grpcfd` functionality. 

So, there are a couple of places where `sendFDs` and `errChs` are not protected by `sendExecutor`. If we run `Close` and `Write` functions in concurrency mode - we can get a panic.

`connWrap` implements `net.Conn` that says:
 `// Multiple goroutines may invoke methods on a Conn simultaneously.`
https://github.com/golang/go/blob/master/src/net/net.go#L112

**_It is not tested yet. Please don't merge._**




Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>