### PR TITLE
Add tests based on how many open fds are at a time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,18 @@ go 1.22
 require (
 	github.com/edwarnicke/serialize v1.0.7
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.10.0
 	google.golang.org/grpc v1.58.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/edwarnicke/serialize v1.0.7 h1:geX8vmyu8Ij2S5fFIXjy9gBDkKxXnrMIzMoDvV0Ddac=
 github.com/edwarnicke/serialize v1.0.7/go.mod h1:y79KgU2P7ALH/4j37uTSIdNavHFNttqN7pzO6Y8B2aw=
@@ -7,13 +8,17 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
@@ -46,5 +51,7 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/test/internal/mock/client.go
+++ b/test/internal/mock/client.go
@@ -1,0 +1,106 @@
+// Package mock adds helper classes to ease grpc server and client creation
+package mock
+
+import (
+	"context"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	health "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/edwarnicke/grpcfd"
+	"github.com/pkg/errors"
+)
+
+type sendfileCallbackType func(grpcfd.FDTransceiver) (<-chan error, string)
+
+type Client struct {
+	socketname        string
+	perRPCCredentials credentials.PerRPCCredentials
+	conn              *grpc.ClientConn
+	sender            grpcfd.FDTransceiver
+	cli               health.HealthClient
+	sendfileMethod    sendfileCallbackType
+}
+
+func NewClient(socketname string, sendfile sendfileCallbackType) *Client {
+	return &Client{
+		socketname:        socketname,
+		perRPCCredentials: grpcfd.PerRPCCredentials(nil),
+		sendfileMethod:    sendfile,
+	}
+}
+
+func (c *Client) Close() error {
+	if c.conn != nil {
+		err := c.conn.Close()
+		c.conn = nil
+		return err
+	}
+	return nil
+}
+
+func (c *Client) Dial() error {
+	if c.conn != nil {
+		panic("conn was not nil!")
+	}
+	var opts []grpc.DialOption
+	opts = append(opts,
+		grpc.WithTransportCredentials(
+			grpcfd.TransportCredentials(insecure.NewCredentials())),
+		grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(
+			grpc.WaitForReady(true)),
+	)
+
+	conn, err := grpc.Dial("unix:"+c.socketname, opts...)
+	c.conn = conn
+	return err
+}
+
+func (c *Client) Send(ctx context.Context) error {
+	if c.sendfileMethod == nil {
+		return errors.New("Use send Dummy, or specify a callback")
+	}
+	sender, ok := grpcfd.FromPerRPCCredentials(c.perRPCCredentials)
+	if !ok {
+		return errors.New("Failed to create grpcfd.Transceiver from rpcCredentials!")
+	}
+	c.sender = sender
+	errCh, filename := c.sendfileMethod(c.sender)
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+	}
+
+	f := health.HealthCheckRequest{Service: filename}
+
+	c.cli = health.NewHealthClient(c.conn)
+	_, err := c.cli.Check(ctx, &f, grpc.PerRPCCredentials(c.perRPCCredentials))
+	return err
+}
+
+func (c *Client) Recv(ctx context.Context, filename string) (<-chan *os.File, error) {
+	sender, ok := grpcfd.FromPerRPCCredentials(c.perRPCCredentials)
+	if !ok {
+		return nil, errors.New("Failed to create grpcfd.Transceiver from rpcCredentials!")
+	}
+	c.sender = sender
+
+	c.cli = health.NewHealthClient(c.conn)
+	hc := health.HealthCheckRequest{}
+	_, err := c.cli.Check(ctx, &hc, grpc.PerRPCCredentials(c.perRPCCredentials))
+	if err != nil {
+		return nil, err
+	}
+	url, err := grpcfd.FilenameToURL(filename)
+	if err != nil {
+		return nil, err
+	}
+	fch, err := sender.RecvFileByURL(url.String())
+	return fch, err
+}

--- a/test/internal/mock/server.go
+++ b/test/internal/mock/server.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/edwarnicke/grpcfd"
+	"github.com/pkg/errors"
+
+	health "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+//---------------------------------------------------------------------------//
+
+type callbackType = func(grpcfd.FDTransceiver, string) (*health.HealthCheckResponse, error)
+
+type MockServer struct {
+	health.UnimplementedHealthServer
+	callback callbackType
+}
+
+func NewMockServer(cb callbackType) *MockServer {
+	return &MockServer{
+		callback: cb,
+	}
+}
+func (s *MockServer) Check(ctx context.Context, hc *health.HealthCheckRequest) (*health.HealthCheckResponse, error) {
+	recv, ok := grpcfd.FromContext(ctx)
+	if !ok {
+		err := errors.New("Couldn't get FDReceiver from context!")
+		return nil, err
+	}
+	return s.callback(recv, hc.Service)
+}

--- a/test/internal/openfdcount/openfdcount.go
+++ b/test/internal/openfdcount/openfdcount.go
@@ -1,0 +1,105 @@
+// Package openfdcount counts ho many open references are to a file
+//
+// it uses 'fuser' to get which pids use the specified filename, and then greps through /proc/<pid>/fdinfo/, to get how
+// many times the process has opened the file.
+//
+// caviats: It will not show file references if after open the file has been deleted, but has not yet been closed.
+package openfdcount
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"syscall"
+
+	"github.com/edwarnicke/grpcfd"
+	"github.com/pkg/errors"
+)
+
+func emptyByteSilce() []byte {
+	return []byte{}
+}
+
+func FilenameToInode(filename string) (uint64, error) {
+	fileinfo, err := os.Stat(filename)
+	if err != nil {
+		return 0, err
+	}
+	stat := fileinfo.Sys()
+	inode := stat.(*syscall.Stat_t).Ino
+	return inode, nil
+}
+
+func FilenameToDevIno(filename string) (dev, ino uint64, err error) {
+	u, err := grpcfd.FilenameToURL(filename)
+	if err != nil {
+		return 0, 0, err
+	}
+	return grpcfd.URLToDevIno(u)
+}
+
+func fuser(filename string) ([]string, error) {
+	cmd := exec.Command("/usr/bin/fuser", filename)
+	res, err := cmd.CombinedOutput()
+
+	if err != nil && len(res) == 0 {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.New(string(res))
+	}
+
+	s := string(res)
+	s = strings.Trim(s, " \n")
+	slc := strings.Split(s, ":")
+	s = strings.Trim(slc[1], " \n")
+	slc = strings.Split(s, " ")
+	slc = slices.DeleteFunc(slc, func(elem string) bool {
+		return elem == ""
+	})
+
+	return slc, nil
+}
+
+func OpenFDCount(filename string) (int, error) {
+	slc, err := fuser(filename)
+	if err != nil {
+		return 0, err
+	}
+	_, ino, err := FilenameToDevIno(filename)
+	if err != nil {
+		return 0, err
+	}
+	ocount := 0
+	for _, pid := range slc {
+		fdinfo := "/proc/" + pid + "/fdinfo"
+		entries, err := os.ReadDir(fdinfo)
+		if err != nil {
+			return 0, err
+		}
+		for _, entry := range entries {
+			entryPath := fdinfo + "/" + entry.Name()
+			_, err := os.Stat(entryPath)
+			if err != nil {
+				continue
+			}
+			// #nosec: 204 I couldn't find any other workaround to this, and inside fdinfo there shouldn't be anything  malicious
+			res, err := exec.Command("grep", "-e", "^ino:\t"+fmt.Sprint(ino), entryPath).CombinedOutput()
+			switch e := err.(type) {
+			case *exec.ExitError:
+				switch ec := e.ProcessState.ExitCode(); ec {
+				case 0: // exit success, exec.Command should not return error, handle it at the default branch in the outer switch
+				case 1: // there was no match in grep, do not increment count
+				default:
+					return 0, errors.Errorf("grep returned with error: %v, exit_code: %d stoud: %v", err, ec, string(res))
+				}
+			case error:
+				return 0, errors.Errorf("grep returned with error: %v", err)
+			default:
+				ocount++
+			}
+		}
+	}
+	return ocount, nil
+}

--- a/test/internal/openfdcount/openfdcount_test.go
+++ b/test/internal/openfdcount/openfdcount_test.go
@@ -1,0 +1,133 @@
+package openfdcount
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------//
+const (
+	testFilename = "/tmp/myrandomtestfile.txt"
+	N            = 10
+)
+
+// ---------------------------------------------------------------------------/
+
+func touch(filename string) error {
+	filename = filepath.Clean(filename)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func TestGetCount(t *testing.T) {
+	f, err := os.OpenFile(testFilename, os.O_CREATE|os.O_RDONLY, 0o600)
+	t.Cleanup(func() {
+		assert.NoError(t, os.Remove(testFilename))
+	})
+	defer func() {
+		assert.NoError(t, f.Close())
+	}()
+	assert.NoError(t, err)
+
+	f2, err := os.OpenFile(testFilename, os.O_CREATE|os.O_RDONLY, 0o600)
+	defer func() {
+		assert.NoError(t, f2.Close())
+	}()
+	assert.NoError(t, err)
+
+	opencount, err := OpenFDCount(testFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, opencount, "Opencount should be 2 since we opened the file two times.")
+}
+
+func TestGetCountNoFile(t *testing.T) {
+	_, err := OpenFDCount(testFilename)
+	assert.NotNil(t, err)
+}
+
+func TestGetCountNoOpen(t *testing.T) {
+	err := touch(testFilename)
+	assert.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.Remove(testFilename)) })
+
+	opencount, err := OpenFDCount(testFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, opencount)
+}
+
+func TestGetCountMultipleProcesses(t *testing.T) {
+	f, err := os.OpenFile(testFilename, os.O_CREATE|os.O_RDONLY, 0o600)
+	assert.NoError(t, err)
+	err = f.Sync()
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, f.Close())
+		assert.NoError(t, os.Remove(testFilename))
+	})
+	opencount, err := OpenFDCount(testFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, opencount)
+
+	cmd := exec.Command("tail", "-f", testFilename)
+	err = cmd.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, cmd.Process.Kill())
+		er := cmd.Wait()
+		switch e := er.(type) {
+		case *exec.ExitError:
+			// since we issued a kill signal the wait should return -1 exit code according to https://pkg.go.dev/os#Process.Wait
+			// its a bit weird though as its also the same return value for a process that has not exited
+			assert.Equal(t, -1, e.ProcessState.ExitCode())
+		default:
+			t.Error(er)
+		}
+	}()
+
+	opencount, err = OpenFDCount(testFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, opencount)
+
+	f2, err := os.OpenFile(testFilename, os.O_CREATE|os.O_RDONLY, 0o600)
+	assert.NoError(t, err)
+	opencount, err = OpenFDCount(testFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, opencount)
+	assert.NoError(t, f2.Close())
+	opencount, err = OpenFDCount(testFilename)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, opencount)
+}
+
+func TestGetCountN(t *testing.T) {
+	fileArray := make([]*os.File, N)
+	t.Cleanup(func() {
+		assert.NoError(t, os.Remove(testFilename))
+	})
+	for i := 0; i < N; i++ {
+		f, err := os.OpenFile(testFilename, os.O_CREATE|os.O_RDONLY, 0o600)
+		assert.NoError(t, err)
+		fileArray[i] = f
+		opencount, err := OpenFDCount(testFilename)
+		assert.NoError(t, err)
+		t.Logf("after %d open(s) opencount of %s: %d\n", i+1, testFilename, opencount)
+		assert.Equal(t, i+1, opencount)
+	}
+	for i := 0; i < N; i++ {
+		assert.NoError(t, fileArray[i].Close())
+		opencount, err := OpenFDCount(testFilename)
+		assert.NoError(t, err)
+		t.Logf("after %d close(s) opencount of %s: %d\n", i+1, testFilename, opencount)
+		assert.Equal(t, N-i-1, opencount)
+	}
+}

--- a/test/openfdcounts_test.go
+++ b/test/openfdcounts_test.go
@@ -1,0 +1,375 @@
+package test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	health "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/edwarnicke/grpcfd"
+	"github.com/edwarnicke/grpcfd/test/internal/mock"
+	"github.com/edwarnicke/grpcfd/test/internal/openfdcount"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	socketname = "/tmp/abracadbra.sock"
+	filename   = "/tmp/randomfiletosend.txt"
+	N          = 16
+)
+
+type callbackType = func(cvr grpcfd.FDTransceiver, filename string) (*health.HealthCheckResponse, error)
+
+func keys[K comparable, V any](m map[K]V) []K {
+	ks := make([]K, 0)
+	for key := range m {
+		ks = append(ks, key)
+	}
+	return ks
+}
+
+func assertFdCount(t *testing.T, filename string, ofdcount int) {
+	t.Helper()
+	cnt, err := openfdcount.OpenFDCount(filename)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if cnt != ofdcount {
+		t.Errorf("open fd count excpected: %d, got: %d\n", ofdcount, cnt)
+	}
+}
+
+func fatalOnErr(t *testing.T, e error) {
+	t.Helper()
+	if e != nil {
+		t.Fatal(e)
+	}
+}
+
+func touch(filename string) error {
+	filename = filepath.Clean(filename)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func makeMockSrv(t *testing.T, openfdcnt int) callbackType {
+	return func(cvr grpcfd.FDTransceiver, filename string) (*health.HealthCheckResponse, error) {
+		url, err := grpcfd.FilenameToURL(filename)
+		assert.NoError(t, err)
+		ch, err := cvr.RecvFileByURL(url.String())
+		assert.NoError(t, err)
+
+		assertFdCount(t, filename, openfdcnt+2)
+
+		file := <-ch
+		assert.NoError(t, file.Close())
+
+		assertFdCount(t, filename, openfdcnt+1)
+
+		return &health.HealthCheckResponse{Status: health.HealthCheckResponse_SERVING}, nil
+	}
+}
+
+func setupFiles(t *testing.T, files []string) func() {
+	for _, file := range files {
+		t.Logf("Creating file: %s\n", file)
+		fatalOnErr(t, touch(file))
+	}
+
+	return func() {
+		for _, file := range files {
+			t.Logf("Removing file: %s\n", file)
+			assert.NoError(t, os.Remove(file))
+		}
+	}
+}
+
+func setupServer(t *testing.T, cb callbackType) (server *grpc.Server, cleanup func()) {
+	t.Log("Setting up server")
+	m := mock.NewMockServer(cb)
+	lis, err := net.Listen("unix", socketname)
+	fatalOnErr(t, err)
+	var creds credentials.TransportCredentials
+	srv := grpc.NewServer(grpc.Creds(grpcfd.TransportCredentials(creds)))
+	health.RegisterHealthServer(srv, m)
+
+	t.Log("Start Serve")
+	go func() {
+		err := srv.Serve(lis)
+		assert.NoError(t, err)
+	}()
+	t.Log("Returning cleanup")
+	return srv, func() {
+		err := os.Remove(socketname)
+		if err != nil {
+			switch v := err.(type) {
+			case *os.PathError: // it looks like grpc.Server.Stop() also removes the socket, so I'm checking ENOENT
+				if v.Err == syscall.ENOENT {
+					return
+				}
+			default:
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestTruth(t *testing.T) {
+	assert.NoError(t, nil)
+	assert.Equal(t, 0, 0)
+	fatalOnErr(t, nil)
+	t.Cleanup(setupFiles(t, []string{filename}))
+	assertFdCount(t, filename, 0)
+}
+
+func TestTouch(t *testing.T) {
+	_, err := os.Stat(filename)
+	assert.Error(t, err)
+	err = touch(filename)
+	assert.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.Remove(filename)) })
+	_, err = os.Stat(filename)
+	assert.NoError(t, err)
+
+	_, err = grpcfd.FilenameToURL(filename)
+	assert.NoError(t, err)
+}
+
+func TestSendFile(t *testing.T) {
+	srv, cleanup := setupServer(t, makeMockSrv(t, 1))
+	t.Cleanup(func() {
+		cleanup()
+		srv.Stop()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDONLY, 0o600)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, file.Close())
+		assertFdCount(t, filename, 1)
+	}()
+
+	assertFdCount(t, filename, 1)
+
+	cli := mock.NewClient(socketname, func(sender grpcfd.FDTransceiver) (<-chan error, string) {
+		errCh := sender.SendFile(file)
+		return errCh, filename
+	})
+	err = cli.Dial()
+	assert.NoError(t, err)
+
+	err = cli.Send(ctx)
+	assert.NoError(t, err)
+}
+
+func TestSendFilename(t *testing.T) {
+	t.Cleanup(setupFiles(t, []string{filename}))
+	srv, cleanup := setupServer(t, makeMockSrv(t, 0))
+	t.Cleanup(func() {
+		cleanup()
+		srv.Stop()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	cli := mock.NewClient(socketname, func(sender grpcfd.FDTransceiver) (<-chan error, string) {
+		errCh := sender.SendFilename(filename)
+		assertFdCount(t, filename, 1)
+		return errCh, filename
+	})
+
+	err := cli.Dial()
+	assert.NoError(t, err)
+
+	err = cli.Send(ctx)
+	assert.NoError(t, err)
+
+	// after Send the only fd open should be in srv
+	assertFdCount(t, filename, 1)
+}
+
+func TestSendFail(t *testing.T) {
+	t.Cleanup(setupFiles(t, []string{filename}))
+	srv, cleanup := setupServer(t, makeMockSrv(t, 0))
+	t.Cleanup(cleanup)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	{
+		cli := mock.NewClient(socketname, func(sender grpcfd.FDTransceiver) (<-chan error, string) {
+			errCh := sender.SendFilename(filename)
+			assertFdCount(t, filename, 1)
+			return errCh, filename
+		})
+
+		err := cli.Dial()
+		assert.NoError(t, err)
+
+		srv.Stop()
+		resp := cli.Send(ctx)
+		assert.NotNil(t, resp)
+
+		assertFdCount(t, filename, 1)
+	}
+	runtime.GC()
+	assertFdCount(t, filename, 0)
+}
+
+func TestServerSend(t *testing.T) {
+	t.Cleanup(setupFiles(t, []string{filename}))
+	srv, cleanup := setupServer(t, func(cvr grpcfd.FDTransceiver, _ string) (*health.HealthCheckResponse, error) {
+		assertFdCount(t, filename, 0)
+		errCh := cvr.SendFilename(filename)
+		select {
+		case err := <-errCh:
+			return nil, err
+		default:
+		}
+		assertFdCount(t, filename, 1)
+		return &health.HealthCheckResponse{Status: health.HealthCheckResponse_SERVING}, nil
+	})
+	t.Cleanup(cleanup)
+	defer func() { // should be zero after srv is closed
+		srv.Stop()
+		assertFdCount(t, filename, 0)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	cli := mock.NewClient(socketname, nil)
+	err := cli.Dial()
+	fatalOnErr(t, err)
+	defer func() {
+		assert.NoError(t, os.Remove(socketname))
+	}()
+
+	fileCh, err := cli.Recv(ctx, filename)
+	assert.NoError(t, err)
+
+	f := <-fileCh
+	defer func() {
+		assert.NoError(t, f.Close())
+		assertFdCount(t, filename, 1)
+	}()
+
+	assertFdCount(t, filename, 2)
+}
+
+func TestMultiClient(t *testing.T) {
+	filemap := map[string]int{
+		"/tmp/testfilename1.txt": 0,
+		"/tmp/testfilename2.txt": 0,
+		"/tmp/testfilename3.txt": 0,
+	}
+	t.Cleanup(setupFiles(t, keys(filemap)))
+	srv, cleanup := setupServer(t, func(cvr grpcfd.FDTransceiver, filename string) (*health.HealthCheckResponse, error) {
+		url, err := grpcfd.FilenameToURL(filename)
+		fatalOnErr(t, err)
+		ch, err := cvr.RecvFileByURL(url.String())
+		fatalOnErr(t, err)
+
+		file := <-ch
+		assert.NoError(t, file.Close())
+
+		assertFdCount(t, filename, 1)
+
+		return &health.HealthCheckResponse{Status: health.HealthCheckResponse_SERVING}, nil
+	})
+	t.Cleanup(func() {
+		cleanup()
+		srv.Stop()
+	})
+
+	fun := func() {
+		for filepath := range filemap {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+			defer cancel()
+
+			err := touch(filepath)
+			assert.NoError(t, err)
+
+			cli := mock.NewClient(socketname, func(sender grpcfd.FDTransceiver) (<-chan error, string) {
+				errCh := sender.SendFilename(filepath)
+				filemap[filepath]++
+				return errCh, filepath
+			})
+			err = cli.Dial()
+			assert.NoError(t, err)
+			defer func() {
+				assert.NoError(t, cli.Close())
+			}()
+
+			_ = cli.Send(ctx)
+			assertFdCount(t, filepath, 1)
+		}
+	}
+	for i := 0; i < N; i++ {
+		fun()
+	}
+	for filepath := range filemap {
+		assertFdCount(t, filepath, 0)
+	}
+}
+
+func TestSameFileOverSameConn(t *testing.T) {
+	t.Cleanup(setupFiles(t, []string{filename}))
+	srv, cleanup := setupServer(t, func(cvr grpcfd.FDTransceiver, filename string) (*health.HealthCheckResponse, error) {
+		url, err := grpcfd.FilenameToURL(filename)
+		assert.NoError(t, err)
+		ch, err := cvr.RecvFileByURL(url.String())
+		assert.NoError(t, err)
+
+		file := <-ch
+		assert.NoError(t, file.Close())
+
+		assertFdCount(t, filename, 1)
+
+		return &health.HealthCheckResponse{Status: health.HealthCheckResponse_SERVING}, nil
+	})
+
+	t.Cleanup(func() {
+		cleanup()
+		srv.Stop()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	err := touch(filename)
+	assert.NoError(t, err)
+
+	cli := mock.NewClient(socketname, func(sender grpcfd.FDTransceiver) (<-chan error, string) {
+		errCh := sender.SendFilename(filename)
+		return errCh, filename
+	})
+	err = cli.Dial()
+	fatalOnErr(t, err)
+
+	for i := 0; i < N; i++ {
+		err = cli.Send(ctx)
+		fatalOnErr(t, err)
+		assertFdCount(t, filename, 1)
+	}
+
+	assert.NoError(t, cli.Close())
+	assertFdCount(t, filename, 0)
+}


### PR DESCRIPTION
Hi,

We also tried to make some test based on how the open fd reference counts change during grpcfd usage.

It counts the fd-s with the 'fuser' command from linux to get the pids using a file, and then I just grep through the fdinfo under /proc to get the actual open count.
and during ordinary grpc calls I just check how many times the file is opened.

What do you think is it any good?


